### PR TITLE
Improve `ImmutableList.subList` functionality

### DIFF
--- a/library/collections/src/commonMain/kotlin/io/matthewnelson/immutable/collections/Immutable.kt
+++ b/library/collections/src/commonMain/kotlin/io/matthewnelson/immutable/collections/Immutable.kt
@@ -80,7 +80,12 @@ private class ImmutableList<T>(
     override fun lastIndexOf(element: T): Int = delegate.lastIndexOf(element)
     override fun listIterator(): ListIterator<T> = ImmutableListIterator(delegate.listIterator())
     override fun listIterator(index: Int): ListIterator<T> = ImmutableListIterator(delegate.listIterator(index))
-    override fun subList(fromIndex: Int, toIndex: Int): List<T> = delegate.subList(fromIndex, toIndex).toImmutableList()
+    override fun subList(fromIndex: Int, toIndex: Int): List<T> {
+        if (fromIndex == 0 && toIndex == size) return this
+        val subList = delegate.subList(fromIndex, toIndex)
+        if (subList.isEmpty()) return emptyList()
+        return ImmutableList(subList)
+    }
 }
 
 private class ImmutableSet<T>(

--- a/library/collections/src/commonTest/kotlin/io/matthewnelson/immutable/collections/ImmutableListUnitTest.kt
+++ b/library/collections/src/commonTest/kotlin/io/matthewnelson/immutable/collections/ImmutableListUnitTest.kt
@@ -56,6 +56,7 @@ class ImmutableListUnitTest {
 
     @Test
     fun givenImmutableList_whenSubList_thenReturnsImmutableList() {
+        assertEquals("ImmutableList", list.toImmutableList().subList(0, list.size)::class.simpleName)
         assertEquals("ImmutableList", list.toImmutableList().subList(0, 1)::class.simpleName)
         assertEquals("EmptyList", list.toImmutableList().subList(0, 0)::class.simpleName)
     }


### PR DESCRIPTION
Previously, `subList` would simply hit the `List` returned by delegate with `toImmutableList`. This PR adds minimal logic to mitigate unnecessary object creation by returning itself, `emptyList` or a new `ImmutableList` when appropriate.